### PR TITLE
DJ show bug fix and CSS tweaks

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -16,10 +16,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 <html>
 
 	<head>
-
-		<link rel ="stylesheet" href="css/styles.css">
 		<script src="https://kit.fontawesome.com/ef315d9147.js" crossorigin="anonymous"></script>
-		
 	</head>
 
 	<div class="wrapper" id="wrapper-footer">

--- a/header.php
+++ b/header.php
@@ -32,9 +32,6 @@ $container = get_theme_mod('understrap_container_type');
     <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery-scrollTo/2.1.2/jquery.scrollTo.min.js"></script>
     <!-- History.js -->
     <script src="http://browserstate.github.io/history.js/scripts/bundled/html4+html5/jquery.history.js"></script>
-    <!-- Ajaxify -->
-    <script src="http://rawgithub.com/browserstate/ajaxify/master/ajaxify-html5.js"></script>
-    <script src="src\js\wrbb-js\slider.js"></script>
 
 </head>
 

--- a/loop-templates/content-mainpage.php
+++ b/loop-templates/content-mainpage.php
@@ -17,7 +17,7 @@
         </div>
 
 		<div class="mpa-meta">
-			<?php the_title( sprintf( '<h5 id="title"><a href="%s" rel="bookmark">',
+			<?php the_title( sprintf( '<h5 class="thumbnail-title"><a href="%s" rel="bookmark">',
 				esc_url( get_permalink() ) ), '</a></h5>' );
 
 			if ( 'post' == get_post_type() ) {

--- a/sass/theme/wrbb-styles/dj-show-bio.scss
+++ b/sass/theme/wrbb-styles/dj-show-bio.scss
@@ -1,11 +1,15 @@
 .shows img {
 	width: 270px;
 	height: 200px;
-	margin: 10px 0;
+	margin: 0.5em 0;
 }
 
 .shows p {
 	font-size: 12px;
+}
+
+.menu-show {
+	margin-bottom: 1em;
 }
 
 .single-title {

--- a/sass/theme/wrbb-styles/mainpage.scss
+++ b/sass/theme/wrbb-styles/mainpage.scss
@@ -36,7 +36,7 @@
 	margin: 5px 20px;
 }
 
-.mpa-meta #title {
+.thumbnail-title {
 	font-family: 'Playfair Display', serif;
 	font-weight: 900;
 	margin-bottom: 0;

--- a/src/wrbb-templates/dj-show-menu.php
+++ b/src/wrbb-templates/dj-show-menu.php
@@ -47,10 +47,10 @@ array_multisort(array_map('strtolower', array_column($items, 'title')), $items);
                 $endTime = date('-gA', strtotime($show['end']));
                 $time = $startTime . $endTime; ?>
 
-                <div class="col-sm-3">
+                <div class="col-sm-3 menu-show">
                     <a href="<?php bloginfo('url'); ?>/dj-show-bio?id=<?php echo $show['id'] ?>">
                         <img class="thumbnail-image" src="<?php echo $show['image'] ?>">
-                        <h5><?php echo $show['title'] ?></h5>
+                        <h5 class="thumbnail-title"><?php echo $show['title'] ?></h5>
                     </a>
                     <p><?php echo date('l', strtotime($show['start'])) ?> <?php echo $time ?></p>
                 </div>


### PR DESCRIPTION
- Cleaned up JS console errors
- Removed Ajaxify loading from header.php which was causing Javascript not to work until page reload
  - Specifically, on the DJ show bio page, the buttons to cycle through pages of playlists weren't working until you reloaded the page
- Tweaked CSS so the DJ show titles on the menu page have the same font as the homepage and the spacing is a bit better