### PR TITLE
Fixed header dropdowns flashing on load bug

### DIFF
--- a/header.php
+++ b/header.php
@@ -53,7 +53,7 @@ wp_localize_script('jquery', 'php_vars', $js_data);
     <div class="header">
 
         <!-- ******************* The Navbar Area ******************* -->
-        <div id="wrapper-navbar" itemscope itemtype="http://schema.org/WebSite" class="wrbb-navbar">
+        <div id="wrapper-navbar" itemscope itemtype="http://schema.org/WebSite" class="wrbb-navbar display-none">
 
             <div class="header-logo">
                 <a href="<?php echo esc_url(home_url('/')); ?>">

--- a/sass/theme/wrbb-styles/header.scss
+++ b/sass/theme/wrbb-styles/header.scss
@@ -37,6 +37,10 @@
   z-index: 3;
 }
 
+.display-none {
+  display: none;
+}
+
 .menu-item:last-child .dropdown-content {
   right: 0;
 }

--- a/src/js/wrbb-js/header.js
+++ b/src/js/wrbb-js/header.js
@@ -1,6 +1,21 @@
-let isMobile = window.matchMedia("only screen and (max-width: 992px)").matches;
+jQuery(document).ready(() => {
+    let isMobile = window.matchMedia("only screen and (max-width: 992px)").matches;
 
-jQuery(".dropdown-content").hide();
+    jQuery(".dropdown-content").hide();
+    jQuery(".wrbb-navbar").removeClass("display-none");
+
+    if (isMobile) {
+        // Close the header nav when the user clicks outside of it
+        jQuery(document).click(function () {
+            jQuery(".wrbb-menu").removeClass("nav-open");
+            jQuery(".wrbb-navbar").removeClass("nav-open");
+        })
+        // Don't close the nav when the user clicks inside of it
+        jQuery(".wrbb-navbar").click(function (e) {
+            e.stopPropagation();
+        })
+    }
+});
 
 jQuery(".nav-item").on({
     mouseenter: function () {
@@ -34,15 +49,3 @@ jQuery(".navbar-toggler").click(function () {
     jQuery(".wrbb-menu").toggleClass("nav-open");
     jQuery(".wrbb-navbar").toggleClass("nav-open");
 });
-
-if (isMobile) {
-    // Close the header nav when the user clicks outside of it
-    jQuery(document).click(function () {
-        jQuery(".wrbb-menu").removeClass("nav-open");
-        jQuery(".wrbb-navbar").removeClass("nav-open");
-    })
-    // Don't close the nav when the user clicks inside of it
-    jQuery(".wrbb-navbar").click(function (e) {
-        e.stopPropagation();
-    })
-}


### PR DESCRIPTION
Because of new JS logic I added for the header dropdown transitions, the dropdowns were flashing for a split second on page load